### PR TITLE
Feature show.na

### DIFF
--- a/R/S3-methods.R
+++ b/R/S3-methods.R
@@ -37,7 +37,7 @@ print.sjmisc_frq <- function(x, ...) {
     insight::print_color(sprintf(
       "# total N=%i  valid N=%i  mean=%.2f  sd=%.2f\n\n",
       sum(dat$frq, na.rm = TRUE),
-      sum(dat$frq[1:(nrow(dat) - 1)], na.rm = TRUE),
+      sum(dat$frq[0:(nrow(dat) - 1)], na.rm = TRUE),
       attr(dat, "mean", exact = T),
       attr(dat, "sd", exact = T)
     ), "blue")

--- a/R/frq.R
+++ b/R/frq.R
@@ -494,7 +494,7 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
   mydat$valid.prc <- 100 * round(mydat$valid.prc, 4)
 
   # "rename" labels for NA values
-  if (!is.null(mydat$label)) mydat$label[is.na(mydat$label)] <- "NA"
+  if (!is.null(mydat$label)) mydat$label[is.na(mydat$val)] <- "NA"
 
   # save original order
   reihe <- sjlabelled::as_numeric(mydat$val, start.at = 1, keep.labels = F)

--- a/R/frq.R
+++ b/R/frq.R
@@ -318,8 +318,8 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
   # convert NaN and Inf to missing
   x <- zap_inf(x)
 
-  # variable with only mising?
-  if (length(stats::na.omit(x)) == 0) {
+  # variable with only missing?
+  if (length(stats::na.omit(x)) == 0 && show.na == FALSE) {
     mydat <- data.frame(
       val = NA,
       label = NA,

--- a/R/frq.R
+++ b/R/frq.R
@@ -183,7 +183,7 @@ frq <- function(x,
   if (!show.strings)
     x <- dplyr::select_if(x, no_character)
 
-  if (sjmisc::is_empty(stats::na.omit(x))) return(NULL)
+  if ((sjmisc::is_empty(stats::na.omit(x)) && show.na==FALSE) || (sjmisc::is_empty(x, all.na.empty = FALSE))) return(NULL)
 
 
   # group strings

--- a/R/frq.R
+++ b/R/frq.R
@@ -496,11 +496,13 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
   # "rename" labels for NA values
   if (!is.null(mydat$label)) mydat$label[is.na(mydat$val)] <- "NA"
 
-  # save original order
-  reihe <- sjlabelled::as_numeric(mydat$val, start.at = 1, keep.labels = F)
+  if (!all(is.na(mydat$val))) {
+    # save original order
+    reihe <- sjlabelled::as_numeric(mydat$val, start.at = 1, keep.labels = F)
 
-  # sort
-  if (sort.frq == "none") mydat <- mydat[order(reihe), ]
+    # sort
+    if (sort.frq == "none") mydat <- mydat[order(reihe), ]
+  }
 
   # remove NA, if requested
   has.na <- mydat$frq[nrow(mydat)] > 0

--- a/R/frq.R
+++ b/R/frq.R
@@ -156,17 +156,19 @@ frq <- function(x,
   }
 
 
-  # remove empty columns
+  if (show.na!=TRUE) {
+    # remove empty columns
+    
+    rem.col <- empty_cols(x)
+    
+    if (!sjmisc::is_empty(rem.col)) {
+      rem.vars <- colnames(x)[rem.col]
+      x <- remove_empty_cols(x)
 
-  rem.col <- empty_cols(x)
-
-  if (!sjmisc::is_empty(rem.col)) {
-    rem.vars <- colnames(x)[rem.col]
-    x <- remove_empty_cols(x)
-
-    message(sprintf("Following %i variables have only missing values and are not shown:", length(rem.vars)))
-    cat(paste(sprintf("%s [%i]", rem.vars, rem.col), collapse = ", "))
-    cat("\n")
+      message(sprintf("Following %i variables have only missing values and are not shown:", length(rem.vars)))
+      cat(paste(sprintf("%s [%i]", rem.vars, rem.col), collapse = ", "))
+      cat("\n")
+    }
   }
 
 

--- a/R/frq.R
+++ b/R/frq.R
@@ -476,11 +476,13 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
 
   # valid values are one row less, because last row is NA row
   valid.vals <- nrow(mydat) - 1
+  if (!all(is.na(mydat$val))) {
 
-  # sort categories ascending or descending
-  if (!is.null(sort.frq) && (sort.frq == "asc" || sort.frq == "desc")) {
-    ord <- order(mydat$frq[seq_len(valid.vals)], decreasing = (sort.frq == "desc"))
-    mydat <- mydat[c(ord, valid.vals + 1), ]
+    # sort categories ascending or descending
+    if (!is.null(sort.frq) && (sort.frq == "asc" || sort.frq == "desc")) {
+      ord <- order(mydat$frq[seq_len(valid.vals)], decreasing = (sort.frq == "desc"))
+      mydat <- mydat[c(ord, valid.vals + 1), ]
+    }
   }
 
   # raw percentages

--- a/R/is_empty.R
+++ b/R/is_empty.R
@@ -8,12 +8,15 @@
 #' @param first.only Logical, if \code{FALSE} and \code{x} is a character
 #'        vector, each element of \code{x} will be checked if empty. If
 #'        \code{TRUE}, only the first element of \code{x} will be checked.
+#' @param all.na.empty Logical, if \code{x} is a vector with \code{NA}-values 
+#'         only, \code{is_empty} will return \code{FALSE} if \code{all.na.empty==FALSE},
+#'         and will return \code{TRUE} if \code{all.na.empty==TRUE} (default).
 #' @return Logical, \code{TRUE} if \code{x} is a character vector or string and
 #'           is empty, \code{TRUE} if \code{x} is a vector or list and of length 0,
 #'           \code{FALSE} otherwise.
 #'
 #' @note \code{NULL}- or \code{NA}-values are also considered as "empty" (see
-#'         'Examples') and will return \code{TRUE}.
+#'         'Examples') and will return \code{TRUE}, unless \code{all.na.empty==FALSE}.
 #'
 #' @examples
 #' is_empty("test")
@@ -44,9 +47,14 @@
 #' # empty list
 #' is_empty(list(NULL))
 #'
+#' # NA vector
+#' x <- rep(NA,5)
+#' is_empty(x)
+#' is_empty(x, all.na.empty = FALSE)
+#'
 #' @importFrom purrr compact
 #' @export
-is_empty <- function(x, first.only = TRUE) {
+is_empty <- function(x, first.only = TRUE, all.na.empty = TRUE) {
   # do we have a valid vector?
   if (!is.null(x)) {
     # if it's a character, check if we have only one element in that vector
@@ -71,7 +79,7 @@ is_empty <- function(x, first.only = TRUE) {
     }
   }
 
-  any(is.null(x) || zero_len || all(is.na(x)))
+  any(is.null(x) || zero_len || (all.na.empty && all(is.na(x))))
 }
 
 

--- a/man/is_empty.Rd
+++ b/man/is_empty.Rd
@@ -12,7 +12,12 @@ is_empty(x, first.only = TRUE)
 \item{first.only}{Logical, if \code{FALSE} and \code{x} is a character
 vector, each element of \code{x} will be checked if empty. If
 \code{TRUE}, only the first element of \code{x} will be checked.}
+
+\item{all.na.empty}{Logical, if \code{x} is a vector with \code{NA}-values 
+only, \code{is_empty} will return \code{FALSE} if \code{all.na.empty==FALSE},
+and will return \code{TRUE} if \code{all.na.empty==TRUE} (default).}
 }
+
 \value{
 Logical, \code{TRUE} if \code{x} is a character vector or string and
           is empty, \code{TRUE} if \code{x} is a vector or list and of length 0,
@@ -24,7 +29,7 @@ This function checks whether a string or character vector (of
 }
 \note{
 \code{NULL}- or \code{NA}-values are also considered as "empty" (see
-        'Examples') and will return \code{TRUE}.
+        'Examples') and will return \code{TRUE}, unless \code{all.na.empty==FALSE}.
 }
 \examples{
 is_empty("test")
@@ -56,3 +61,8 @@ is_empty(d)
 is_empty(list(NULL))
 
 }
+
+# NA vector
+x <- rep(NA,5)
+is_empty(x)
+is_empty(x, all.na.empty = FALSE)

--- a/man/is_empty.Rd
+++ b/man/is_empty.Rd
@@ -4,7 +4,7 @@
 \alias{is_empty}
 \title{Check whether string, list or vector is empty}
 \usage{
-is_empty(x, first.only = TRUE)
+is_empty(x, first.only = TRUE, all.na.empty = TRUE)
 }
 \arguments{
 \item{x}{String, character vector, list, data.frame or numeric vector or factor.}
@@ -17,7 +17,6 @@ vector, each element of \code{x} will be checked if empty. If
 only, \code{is_empty} will return \code{FALSE} if \code{all.na.empty==FALSE},
 and will return \code{TRUE} if \code{all.na.empty==TRUE} (default).}
 }
-
 \value{
 Logical, \code{TRUE} if \code{x} is a character vector or string and
           is empty, \code{TRUE} if \code{x} is a vector or list and of length 0,
@@ -60,9 +59,9 @@ is_empty(d)
 # empty list
 is_empty(list(NULL))
 
-}
-
 # NA vector
 x <- rep(NA,5)
 is_empty(x)
 is_empty(x, all.na.empty = FALSE)
+
+}


### PR DESCRIPTION
My goal is that if a vector consists only of missing values, `frq` will produce the usual output  when `show.na` is not `FALSE`, instead of `NULL`.

Let explain my case to justify this proposal. I have a big data set for which I want to compute frequencies by group, so I make something like that:
```
df %>% dplyr::group_by(gv1,gv2) %>% frq(my_variable)
```
For some combinations of `gv1` and `gv2` all values of `my_variable` are NA, and with the current version, previous instruction produces an error.
After this pull request, with `show.na = TRUE` or `show.na = "auto"`, `frq` does not return `NULL` any more when `x` is a vector of `NA` values. Instead:
``` r
x <- rep(NA,3); sjmisc::frq(x)
#> 
#> x <lgl>
#> # total N=3  valid N=3  mean=NaN  sd=NA
#> 
#>   val frq label raw.prc valid.prc cum.prc
#>  <NA>   3    NA     100        NA      NA
```

<sup>Created on 2019-07-16 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

I hope you consider at least reasonable this PR. If you think it is not a good idea to make this change, maybe we could consider other ways, like introduce another option in the functions instead of using `show.na`.

Thank you!