### PR TITLE
Solve issue #116 and other minor repairs

### DIFF
--- a/R/frq.R
+++ b/R/frq.R
@@ -239,7 +239,7 @@ frq <- function(x,
   if (!show.strings)
     x <- dplyr::select_if(x, no_character)
 
-  if ((sjmisc::is_empty(stats::na.omit(x)) && show.na == FALSE) || (sjmisc::is_empty(x, all.na.empty = FALSE)))
+  if ((sjmisc::is_empty(stats::na.omit(x), first.only = FALSE) && show.na == FALSE) || (sjmisc::is_empty(x, all.na.empty = FALSE)))
     return(NULL)
 
 
@@ -588,7 +588,7 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
   mydat$valid.prc <- 100 * round(mydat$valid.prc, 4)
 
   # "rename" labels for NA values
-  if (!is.null(mydat$label)) mydat$label[is.na(mydat$val)] <- "<NA>"
+  if (!is.null(mydat$label)) mydat$label[is.na(mydat$val)] <- NA_character_
 
   if (!all(is.na(mydat$val))) {
     if (extra.vals == 1) {

--- a/R/frq.R
+++ b/R/frq.R
@@ -239,7 +239,7 @@ frq <- function(x,
   if (!show.strings)
     x <- dplyr::select_if(x, no_character)
 
-  if ((all(sjmisc::is_empty(stats::na.omit(x), first.only = FALSE)) && show.na == FALSE) || all(replace_na(sjmisc::is_empty(x, first.only = FALSE, all.na.empty = FALSE), value = FALSE)))
+  if ((all(sjmisc::is_empty(stats::na.omit(x), first.only = FALSE)) && show.na == FALSE) || all(suppressMessages(replace_na(sjmisc::is_empty(x, first.only = FALSE, all.na.empty = FALSE), value = FALSE))))
     return(NULL)
 
 

--- a/R/frq.R
+++ b/R/frq.R
@@ -239,7 +239,7 @@ frq <- function(x,
   if (!show.strings)
     x <- dplyr::select_if(x, no_character)
 
-  if ((sjmisc::is_empty(stats::na.omit(x), first.only = FALSE) && show.na == FALSE) || (sjmisc::is_empty(x, first.only = FALSE, all.na.empty = FALSE)))
+  if ((all(sjmisc::is_empty(stats::na.omit(x), first.only = FALSE)) && show.na == FALSE) || all((sjmisc::is_empty(x, first.only = FALSE, all.na.empty = FALSE))))
     return(NULL)
 
 

--- a/R/frq.R
+++ b/R/frq.R
@@ -239,7 +239,7 @@ frq <- function(x,
   if (!show.strings)
     x <- dplyr::select_if(x, no_character)
 
-  if ((all(sjmisc::is_empty(stats::na.omit(x), first.only = FALSE)) && show.na == FALSE) || all((sjmisc::is_empty(x, first.only = FALSE, all.na.empty = FALSE))))
+  if ((all(sjmisc::is_empty(stats::na.omit(x), first.only = FALSE)) && show.na == FALSE) || all(replace_na(sjmisc::is_empty(x, first.only = FALSE, all.na.empty = FALSE), value = FALSE)))
     return(NULL)
 
 

--- a/R/frq.R
+++ b/R/frq.R
@@ -239,7 +239,7 @@ frq <- function(x,
   if (!show.strings)
     x <- dplyr::select_if(x, no_character)
 
-  if ((sjmisc::is_empty(stats::na.omit(x), first.only = FALSE) && show.na == FALSE) || (sjmisc::is_empty(x, all.na.empty = FALSE)))
+  if ((sjmisc::is_empty(stats::na.omit(x), first.only = FALSE) && show.na == FALSE) || (sjmisc::is_empty(x, first.only = FALSE, all.na.empty = FALSE)))
     return(NULL)
 
 

--- a/R/frq.R
+++ b/R/frq.R
@@ -509,6 +509,10 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
 
     colnames(mydat) <- c("val", "frq")
 
+    if (!anyNA(suppressWarnings(as.numeric(attr(mydat$val, "levels"))))) {
+      mydat$val <- sjlabelled::as_numeric(mydat$val, keep.labels = F)
+    }
+
     # add values as label
     mydat$label <- as.character("<none>")
     mydat <- mydat[c("val", "label", "frq")]

--- a/R/is_empty.R
+++ b/R/is_empty.R
@@ -65,8 +65,8 @@ is_empty <- function(x, first.only = TRUE, all.na.empty = TRUE) {
       zero_len <- nchar(x) == 0
       # return result for multiple elements of character vector
       if (first.only) {
-        zero_len <- .is_true(zero_len[!is.na(x) & !is.null(x)][1])
-        if (length(x) > 0) x <- x[!is.na(x) & !is.null(x)][1]
+        zero_len <- .is_true(zero_len[1])
+        if (length(x) > 0) x <- x[1]
       } else {
         return(unname(zero_len))
       }

--- a/R/is_empty.R
+++ b/R/is_empty.R
@@ -8,7 +8,7 @@
 #' @param first.only Logical, if \code{FALSE} and \code{x} is a character
 #'        vector, each element of \code{x} will be checked if empty. If
 #'        \code{TRUE}, only the first element of \code{x} will be checked.
-#' @param all.na.empty Logical, if \code{x} is a vector with \code{NA}-values 
+#' @param all.na.empty Logical, if \code{x} is a vector with \code{NA}-values
 #'         only, \code{is_empty} will return \code{FALSE} if \code{all.na.empty==FALSE},
 #'         and will return \code{TRUE} if \code{all.na.empty==TRUE} (default).
 #' @return Logical, \code{TRUE} if \code{x} is a character vector or string and
@@ -65,8 +65,8 @@ is_empty <- function(x, first.only = TRUE, all.na.empty = TRUE) {
       zero_len <- nchar(x) == 0
       # return result for multiple elements of character vector
       if (first.only) {
-        zero_len <- .is_true(zero_len[1])
-        if (length(x) > 0) x <- x[!is.na(x)][1]
+        zero_len <- .is_true(zero_len[!is.na(x) & !is.null(x)][1])
+        if (length(x) > 0) x <- x[!is.na(x) & !is.null(x)][1]
       } else {
         return(unname(zero_len))
       }

--- a/man/is_empty.Rd
+++ b/man/is_empty.Rd
@@ -13,7 +13,7 @@ is_empty(x, first.only = TRUE, all.na.empty = TRUE)
 vector, each element of \code{x} will be checked if empty. If
 \code{TRUE}, only the first element of \code{x} will be checked.}
 
-\item{all.na.empty}{Logical, if \code{x} is a vector with \code{NA}-values 
+\item{all.na.empty}{Logical, if \code{x} is a vector with \code{NA}-values
 only, \code{is_empty} will return \code{FALSE} if \code{all.na.empty==FALSE},
 and will return \code{TRUE} if \code{all.na.empty==TRUE} (default).}
 }


### PR DESCRIPTION
# Description
This PR:

* solves issue #116 
* Compute also something like `frq(c("",NA))` (looking at this vector as non empty).
* `frq` will keep consistency with `print` method for `data.frame`. In `label` column, `NA` is always printed as `<NA>` (avoiding the [hiding issue](https://github.com/yihui/knitr/issues/1751) when generating an HTML) In `val` column, if non `NA` values are strings, same that for labels, else `NA` is printed as `NA`.

For the first two items, the main changes are those in line 242 of `frq.r`. Changes in `is_empty.r` solve other possible strange behaviours.

The other changes in `frq.r` depend on the last item; in order to avoid the hiding issue I use `NA_character_` instead of `"<NA>"`. In order to keep consistency I introduce new lines 512:515.