### PR TITLE
word_wrap.R: Don't perform any checks if word_wrap is disabled. 

### DIFF
--- a/R/word_wrap.R
+++ b/R/word_wrap.R
@@ -21,12 +21,17 @@
 #' @importFrom stats na.omit
 #' @export
 word_wrap <- function(labels, wrap, linesep = NULL) {
+  # infinite wrap? then return labels
+  if (is.infinite(wrap) | wrap == 0) return(labels)
+  # expressions can't be wrapped
+  if (is.expression(labels)) {
+    warning("Word wrap is not available for expressions.")
+    return(labels)
+  }
   # check if labels have NA values and remove them
   if (anyNA(labels)) labels <- as.character(stats::na.omit(labels))
   # check for valid value
   if (is.null(labels) || length(labels) == 0) return(NULL)
-  # infinite wrap? then return labels
-  if (is.infinite(wrap)) return(labels)
   # coerce to character, if factor
   if (!is.character(labels)) labels <- as.character(labels)
   # default line separator is \n


### PR DESCRIPTION
Disable word_wrap for expressions. Add 0 for no Word_Wrap.

Hello Daniel,

I tried to use an expression for labeling a sjPlot plot. This is needed if you want to include summary statistics or model performance parameters in plot labels (i.e. α or μ). Or when using trademarked questionnaires (Index™). Right now `word_wrap()` fails, since `anyNA()` fails on expressions.

There are two ways to achieve this.

1. Manual disabling off `word_wrap()`
2. Automatic disabling of `word_wrap()` for expressions

Disabling `word_wrap()` with `Inf` didn't help, because of the NA checks which were performed and failed earlier in the code. That's why I moved this code to the front. When `word_wrap()` is disabled no checks should be performed. (Am I missing something?)

Also I added 0 for disabling `word_wrap()`, since this was my intuitive choice. Information about how to disable `word_wrap()` is not given in most sjPlot functions. (Maybe add this?)

For the 2. point `word_wrap()` will not try to wrap expressions and will give a warning. If the user wants to use expressions he has to define line breaks by hand.

Please let me know if you want any changes.

Greetings,
Alex
