### PR TITLE
Minor update

### DIFF
--- a/R/S3-methods.R
+++ b/R/S3-methods.R
@@ -43,7 +43,7 @@ print.sjmisc_frq <- function(x, ...) {
     ), "blue")
 
     # don't print labels, if all except for the NA value are "none"
-    if ((dplyr::n_distinct(dat$label[!is.na(dat$val)]) == 1 && unique(dat$label[!is.na(dat$val)]) == "<none>") || (length(dat$val) == 1 && is.na(dat$val)))
+    if (!is.null(dat$label) && ((dplyr::n_distinct(dat$label[!is.na(dat$val)]) == 1 && unique(dat$label[!is.na(dat$val)]) == "<none>") || (length(dat$val) == 1 && is.na(dat$val))))
       dat <- dplyr::select(dat, -.data$label)
 
     # print frq-table

--- a/R/frq.R
+++ b/R/frq.R
@@ -532,13 +532,19 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
       label = "<none>",
       frq = sum(mydatS2$frq)
     )
+	  if (mydatS3$frq == 0) {
+		  mydat <- mydatS1
+	  } else {
+		  mydat <- rbind(mydatS1, mydatS3)
 
-	  mydat <- rbind(mydatS1, mydatS3)
+		  rows.length <- length(row.names(mydat))
 
-	  row.names(mydat) <- c(
-	    row.names(mydat)[-length(row.names(mydat))],
-	    as.character(as.integer(row.names(mydat)[length(row.names(mydat)) - 1]) + 1)
-	  )
+		  row.names(mydat) <- c(
+					row.names(mydat)[-c(rows.length, rows.length - 1)],
+					as.character(as.integer(row.names(mydat)[rows.length - 1]) + 1),
+					row.names(mydat)[rows.length - 1]
+		  )
+	  }
   }
 
   # need numeric

--- a/R/frq.R
+++ b/R/frq.R
@@ -35,6 +35,8 @@
 #'   frequencies are shown. All values or categories that have less than
 #'   \code{min.frq} occurences in the data will be summarized in a \code{"n < 100"}
 #'   category.
+#' @param rm.labels Logical, if \code{TRUE}, \code{label} column is removed from
+#'   \code{frq} output. Default is \code{FALSE}.
 #' @param title String, will be used as alternative title to the variable
 #'   label. If \code{x} is a grouped data frame, \code{title} must be a
 #'   vector of same length as groups.

--- a/R/frq.R
+++ b/R/frq.R
@@ -164,6 +164,7 @@ frq <- function(x,
                 show.na = TRUE,
                 grp.strings = NULL,
                 min.frq = 0,
+		rm.labels = FALSE,
                 out = c("txt", "viewer", "browser"),
                 title = NULL,
                 encoding = "UTF-8",
@@ -310,7 +311,8 @@ frq <- function(x,
               auto.grp = auto.grp,
               title = gr.title,
               show.na = show.na,
-              min.frq = min.frq
+              min.frq = min.frq,
+	      rm.labels = rm.labels
             )
 
           attr(dummy, "group") <- get_grouped_title(x, grps, i, sep = ", ", long = FALSE)
@@ -343,7 +345,8 @@ frq <- function(x,
             auto.grp = auto.grp,
             title = title,
             show.na = show.na,
-            min.frq = min.frq
+            min.frq = min.frq,
+	    rm.labels = rm.labels
           )
 
         # save data frame for return value
@@ -370,7 +373,7 @@ frq <- function(x,
 #' @importFrom dplyr n_distinct full_join bind_rows
 #' @importFrom stats na.omit xtabs na.pass sd weighted.mean
 #' @importFrom sjlabelled get_labels get_label as_numeric
-frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.na = TRUE, min.frq = 0) {
+frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.na = TRUE, min.frq = 0, rm.labels = FALSE) {
   # remember type
   vartype <- var_type(x)
 
@@ -612,6 +615,13 @@ frq_helper <- function(x, sort.frq, weight.by, cn, auto.grp, title = NULL, show.
   has.na <- mydat$frq[nrow(mydat)] > 0
   if ((!is.logical(show.na) && show.na == "auto" && !has.na) || identical(show.na, FALSE))
     mydat <- mydat[-nrow(mydat), ]
+
+
+  # remove labels if rm.labels == TRUE
+  if (isTRUE(rm.labels)) {
+	  mydat$label <- NULL
+  }
+
 
   # add variable label and type as attribute, for print-method
 

--- a/R/frq.R
+++ b/R/frq.R
@@ -75,6 +75,9 @@
 #' data(efc)
 #' frq(efc$e42dep)
 #'
+#' # remove labels
+#' frq(efc$e42dep, rm.labels = TRUE)
+#'
 #' # with grouped data frames, in a pipe
 #' library(dplyr)
 #' efc %>%

--- a/man/frq.Rd
+++ b/man/frq.Rd
@@ -6,8 +6,9 @@
 \usage{
 frq(x, ..., sort.frq = c("none", "asc", "desc"), weights = NULL,
   auto.grp = NULL, show.strings = TRUE, show.na = TRUE,
-  grp.strings = NULL, min.frq = 0, out = c("txt", "viewer",
-  "browser"), title = NULL, encoding = "UTF-8", file = NULL)
+  grp.strings = NULL, min.frq = 0, rm.labels = FALSE,
+  out = c("txt", "viewer", "browser"), title = NULL,
+  encoding = "UTF-8", file = NULL)
 }
 \arguments{
 \item{x}{A vector or a data frame. May also be a grouped data frame
@@ -59,6 +60,9 @@ frequencies are shown. All values or categories that have less than
 \code{min.frq} occurences in the data will be summarized in a \code{"n < 100"}
 category.}
 
+\item{rm.labels}{Logical, if \code{TRUE}, \code{label} column is removed from
+\code{frq} output. Default is \code{FALSE}.}
+
 \item{out}{Character vector, indicating whether the results should be printed
 to console (\code{out = "txt"}) or as HTML-table in the viewer-pane
 (\code{out = "viewer"}) or browser (\code{out = "browser"}).}
@@ -103,6 +107,9 @@ The \dots-argument not only accepts variable names or expressions
 # simple vector
 data(efc)
 frq(efc$e42dep)
+
+# remove labels
+frq(efc$e42dep, rm.labels = TRUE)
 
 # with grouped data frames, in a pipe
 library(dplyr)


### PR DESCRIPTION
This PR aims to improve some minor issues related to the option `min.frq`, and adds the option `rm.labels` in `frq.R`. 

I will explain with a couple of examples.

First, you may have a labelled variable with some labels for which there are no data. They appear in the frequency data frame with `frq==0`, for example the label `cousin` in:
```
> efc %>% filter(e15relat!=7) %>% frq(e15relat)

relationship to elder (e15relat) <numeric>
# total N=895  valid N=895  mean=2.82  sd=2.06

 val                   label frq raw.prc valid.prc cum.prc
   1          spouse/partner 171   19.11     19.11   19.11
   2                   child 473   52.85     52.85   71.96
   3                 sibling  29    3.24      3.24   75.20
   4 daughter or son -in-law  85    9.50      9.50   84.69
   5              ancle/aunt  23    2.57      2.57   87.26
   6            nephew/niece  22    2.46      2.46   89.72
   7                  cousin   0    0.00      0.00   89.72
   8          other, specify  92   10.28     10.28  100.00
  NA                    <NA>   0    0.00        NA      NA
```
When adding `min.frq = 1`, the frequency of `cousin` was used to build the `min.frq` row, obtaining:
```
relationship to elder (e15relat) <numeric>
# total N=895  valid N=895  mean=2.82  sd=2.06

   val                   label frq raw.prc valid.prc cum.prc
     1          spouse/partner 171   19.11     19.11   19.11
     2                   child 473   52.85     52.85   71.96
     3                 sibling  29    3.24      3.24   75.20
     4 daughter or son -in-law  85    9.50      9.50   84.69
     5              ancle/aunt  23    2.57      2.57   87.26
     6            nephew/niece  22    2.46      2.46   89.72
     8          other, specify  92   10.28     10.28  100.00
 n < 1                  <none>   0    0.00      0.00  100.00
  <NA>                    <NA>   0    0.00        NA      NA
```
But, since the `n<1` row has no relevant information (`0` frequency and empty label) I believe it should be removed. Therefore, I introduced the `if-else` in lines `540-542` of `frq.R`, obtaining now:
```
relationship to elder (e15relat) <numeric>
# total N=895  valid N=895  mean=2.82  sd=2.06

 val                   label frq raw.prc valid.prc cum.prc
   1          spouse/partner 171   19.11     19.11   19.11
   2                   child 473   52.85     52.85   71.96
   3                 sibling  29    3.24      3.24   75.20
   4 daughter or son -in-law  85    9.50      9.50   84.69
   5              ancle/aunt  23    2.57      2.57   87.26
   6            nephew/niece  22    2.46      2.46   89.72
   8          other, specify  92   10.28     10.28  100.00
  NA                    <NA>   0    0.00        NA      NA
```

To explain the other two changes I will introduce another example, but previously I try to explain the problem.
With my real data, I needed to compute the frequencies of a list of variables in a data frame, but I wanted to filter disctinct subsets of this data frame depending on the variable. 
More generally, one may need to compute the frequencies of a list of variables of a data frame (or maybe more than one), applying a function before, with a structure as `sapply(list_of_variables, function_with_frq)`.
My example is a bit more simple. I just modify `min.frq` for each variable. I show first the current instruction and output:
```
> sapply(list(list("cyl",10), list("gear",14), list("vs",10), list("carb", 5)),function(item) frq(mtcars[[item[[1]]]],min.frq = item[[2]]))
[[1]]
     val  label frq raw.prc valid.prc cum.prc
1      4 <none>  11   34.38     34.38   34.38
3      8 <none>  14   43.75     43.75   78.12
5 n < 10 <none>   7   21.88     21.88  100.00
4   <NA>   <NA>   0    0.00        NA      NA

[[2]]
     val  label frq raw.prc valid.prc cum.prc
1      3 <none>  15   46.88     46.88   46.88
5 n < 14 <none>  17   53.12     53.12  100.00
4   <NA>   <NA>   0    0.00        NA      NA

[[3]]
  val  label frq raw.prc valid.prc cum.prc
1   0 <none>  18   56.25     56.25   56.25
2   1 <none>  14   43.75     43.75  100.00
3  NA   <NA>   0    0.00        NA      NA

[[4]]
    val  label frq raw.prc valid.prc cum.prc
1     1 <none>   7   21.88     21.88   21.88
2     2 <none>  10   31.25     31.25   53.12
4     4 <none>  10   31.25     31.25   84.38
8 n < 5 <none>   5   15.62     15.62  100.00
7  <NA>   <NA>   0    0.00        NA      NA
```
Here the `frq` output is not printed through the `print` method for `frq`, but for `data frame`, so I tried to improve this output.
The two issues I changed were:
* First, the names of the rows, since I would expect the `n < ` row, which appear before the `<NA>` row, had a previous row number (changed in lines 547-550) of `frq.R`
* Second, I introduced the `rm.labels` option to get the possibility of removing the labels (other lines of `frq.R` and taken into account in line 46 of `S3-methods.R`).

Therefore I can use this option and get the output below:
```
> sapply(list(list("cyl",10), list("gear",14), list("vs",10), list("carb", 5)),function(item) frq(mtcars[[item[[1]]]],min.frq = item[[2]], rm.labels = T))
[[1]]
     val frq raw.prc valid.prc cum.prc
1      4  11   34.38     34.38   34.38
3      8  14   43.75     43.75   78.12
4 n < 10   7   21.88     21.88  100.00
5   <NA>   0    0.00        NA      NA

[[2]]
     val frq raw.prc valid.prc cum.prc
1      3  15   46.88     46.88   46.88
4 n < 14  17   53.12     53.12  100.00
5   <NA>   0    0.00        NA      NA

[[3]]
  val frq raw.prc valid.prc cum.prc
1   0  18   56.25     56.25   56.25
2   1  14   43.75     43.75  100.00
3  NA   0    0.00        NA      NA

[[4]]
    val frq raw.prc valid.prc cum.prc
1     1   7   21.88     21.88   21.88
2     2  10   31.25     31.25   53.12
4     4  10   31.25     31.25   84.38
7 n < 5   5   15.62     15.62  100.00
8  <NA>   0    0.00        NA      NA
```
Let me know any other modification I should make.

Thank you!
