### PR TITLE
Bug/issue 122

### DIFF
--- a/R/rec.R
+++ b/R/rec.R
@@ -104,7 +104,7 @@
 #'   mutate(dependency_rev = rec(e42dep, rec = "rev")) %>%
 #'   head()
 #'
-#' # recode 1 to 3 into 4 into 2
+#' # recode 1 to 3 into 1 and 4 into 2
 #' table(rec(efc$e42dep, rec = "min:3=1; 4=2"), useNA = "always")
 #'
 #' # recode 2 to 1 and all others into 2

--- a/R/rec.R
+++ b/R/rec.R
@@ -562,7 +562,7 @@ rec_helper <- function(x, recodes, as.num, var.label, val.labels) {
 
       } else {
         # else we have numeric values, which should be replaced
-        new_var[which(x == old_val[k])] <- new_val
+        new_var[which(gsub(" ", "", x) == old_val[k])] <- new_val
       }
     }
   }

--- a/man/rec.Rd
+++ b/man/rec.Rd
@@ -127,7 +127,7 @@ efc \%>\%
   mutate(dependency_rev = rec(e42dep, rec = "rev")) \%>\%
   head()
 
-# recode 1 to 3 into 4 into 2
+# recode 1 to 3 into 1 and 4 into 2
 table(rec(efc$e42dep, rec = "min:3=1; 4=2"), useNA = "always")
 
 # recode 2 to 1 and all others into 2


### PR DESCRIPTION
Fix issue #122, so it allows old character categories with spaces.

Yet, it does not take into account the number of spaces, so that if a category is `Category 1` with one space and a different number of spaces is written in the function, for example <pre>rec = "Category       1 = 1"</pre>, it works as if the category has no spaces anywhere.